### PR TITLE
Added a link to Apache Unomi documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 Apache Unomi tracker
 ============
 - [Apache Unomi website](https://unomi.apache.org)
+- [Apache Unomi Documentation](https://unomi.apache.org/manual/latest/)
 - [Versioning and release process](RELEASE.md)
 
 A JavaScript tracker library for Apache Unomi.


### PR DESCRIPTION
The link will make it easier for developer discovering the tracker via npmjs (or the repo itself) to understand where to find the documentation.