### PR TITLE
Add AGENTS.md + SECURITY.md security-model discoverability pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/legal/release-policy.html -->
+
+# Agent Guide for unomi-tracker
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+unomi-tracker is the client-side JS tracker; the project-wide threat model lives in apache/unomi.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@ Security model: [SECURITY.md](./SECURITY.md)
 Agents that scan this repository should consult `SECURITY.md` and the
 threat model it links before reporting issues.
 
-unomi-tracker is the client-side JS tracker; the project-wide threat model lives in apache/unomi.
+Apache Unomi tracker is the client-side JS tracker; the project-wide threat model lives in `apache/unomi`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/legal/release-policy.html -->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/unomi-tracker` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in <https://github.com/apache/unomi/blob/master/THREAT_MODEL.md>.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement.

This adds `AGENTS.md` + `SECURITY.md` to `unomi-tracker` so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → model` chain. The model itself lives in the umbrella `apache/unomi` repo (`THREAT_MODEL.md`); these files only point at it — no model content is added here.

Context: the ASF Security team is preparing the Unomi repos for an automated agentic security scan we're piloting. Such scans refuse to run if the model isn't discoverable by that path (refusing upfront beats a noise-heavy run against a model the agent never found). The Security team has reached out separately on the PMC's private list with the program details.

Questions / pushback welcome — happy to adjust the wording or move the section if the project has a house style.
