### PR TITLE
Align AGENTS.md and SECURITY.md with repo doc conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,21 @@
-<!-- SPDX-License-Identifier: Apache-2.0
-     https://www.apache.org/legal/release-policy.html -->
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
-# Agent Guide for unomi-tracker
+# Agent Guide for Apache Unomi tracker
 
 This file is read by automated agents (security scanners, code
 analyzers, AI assistants) operating on this repository.
@@ -13,4 +27,4 @@ Security model: [SECURITY.md](./SECURITY.md)
 Agents that scan this repository should consult `SECURITY.md` and the
 threat model it links before reporting issues.
 
-Apache Unomi tracker is the client-side JS tracker; the project-wide threat model lives in `apache/unomi`.
+Apache Unomi tracker is the client-side JS tracker; the project-wide threat model lives in [apache/unomi](https://github.com/apache/unomi).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,19 @@
-<!-- SPDX-License-Identifier: Apache-2.0
-     https://www.apache.org/legal/release-policy.html -->
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
 # Security Policy
 


### PR DESCRIPTION
## Summary

Follow-up housekeeping after merging #24 (ASF security-model discoverability pointers):

- Replace SPDX-only headers in `AGENTS.md` and `SECURITY.md` with the standard ASF license comment block used in `README.md` and `RELEASE.md`
- Rename the agent guide title to **Apache Unomi tracker** (consistent with README naming)
- Link the umbrella repo in `AGENTS.md` and retype the closing line to avoid any hidden Unicode from the earlier autofix commit

No change to security policy content or the `AGENTS.md` → `SECURITY.md` → `THREAT_MODEL.md` discoverability chain.

## Test plan

- [ ] Verify `AGENTS.md` and `SECURITY.md` headers match `README.md`
- [ ] Confirm rendered markdown title reads "Agent Guide for Apache Unomi tracker"
- [ ] Confirm threat-model link in `SECURITY.md` still resolves